### PR TITLE
630:P3 Spaghetti Code in CoreAPI action dispatch

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -105,6 +105,8 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
     private static final String ACTION_SAVE_SESSION = "saveSession";
     private static final String ACTION_SNAPSHOT_SESSION = "snapshotSession";
 
+    private final Map<String, ApiActionCommand> actionCommands = new HashMap<>();
+
     private static final String ACTION_ACCESS_URL = "accessUrl";
     private static final String ACTION_SHUTDOWN = "shutdown";
     private static final String ACTION_EXCLUDE_FROM_PROXY = "excludeFromProxy";
@@ -495,6 +497,15 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         addApiAction(
                 deprecatedNetworkApi(new ApiAction("setOptionUseProxyChainAuth", PARAMS_BOOLEAN)));
         addApiAction(deprecatedNetworkApi(new ApiAction("setOptionUseSocksProxy", PARAMS_BOOLEAN)));
+
+        registerActionCommands();
+    }
+
+    private void registerActionCommands(){
+        actionCommands.put(ACTION_SAVE_SESSION.toLowerCase(), this::handleSaveSession);
+        actionCommands.put(ACTION_SNAPSHOT_SESSION, this::handleSnapshotSession);
+        actionCommands.put(ACTION_LOAD_SESSION, this::handleLoadSession);
+        actionCommands.put(ACTION_NEW_SESSION, this::handleNewSession);
     }
 
     private <T extends ApiElement> T deprecatedNetworkApi(T element) {
@@ -526,6 +537,11 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+
+        ApiActionCommand command = actionCommands.get(name.toLowerCase());
+        if(command != null){
+            return command.execute(params);
+        }
 
         Session session = Model.getSingleton().getSession();
 
@@ -574,158 +590,6 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                     };
             thread.start();
 
-        } else if (ACTION_SAVE_SESSION.equalsIgnoreCase(
-                name)) { // Ignore case for backwards compatibility
-            Path sessionPath = getSessionPath(params.getString(PARAM_SESSION));
-            String filename = sessionPath.toAbsolutePath().toString();
-
-            final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
-
-            if (Files.exists(sessionPath)) {
-                boolean sameSession = false;
-                if (overwrite && !session.isNewState()) {
-                    try {
-                        sameSession =
-                                Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
-                    } catch (IOException e) {
-                        LOGGER.error("Failed to check if same session path:", e);
-                        throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                    }
-                }
-
-                if (!overwrite || sameSession) {
-                    throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
-                }
-            }
-            this.savingSession = true;
-            try {
-                Control.getSingleton().saveSession(filename, this);
-            } catch (Exception e) {
-                LOGGER.error("Failed to save the session:", e);
-                this.savingSession = false;
-                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-            }
-            // Wait for notification that its worked ok
-            try {
-                while (this.savingSession) {
-                    Thread.sleep(200);
-                }
-            } catch (InterruptedException e) {
-                // Probably not an error
-                LOGGER.debug(e.getMessage(), e);
-            }
-            LOGGER.debug("Can now return after saving session");
-
-        } else if (ACTION_SNAPSHOT_SESSION.equalsIgnoreCase(
-                name)) { // Ignore case for backwards compatibility
-            if (session.isNewState()) {
-                throw new ApiException(ApiException.Type.DOES_NOT_EXIST);
-            }
-
-            List<String> actions = Control.getSingleton().getExtensionLoader().getActiveActions();
-            if (!actions.isEmpty()) {
-                throw new ApiException(
-                        ApiException.Type.BAD_STATE,
-                        "Active actions prevent the session snapshot: " + actions);
-            }
-
-            String fileName = ApiUtils.getOptionalStringParam(params, PARAM_SESSION);
-
-            if (fileName == null || fileName.isEmpty()) {
-                fileName = session.getFileName();
-
-                if (fileName.endsWith(".session")) {
-                    fileName = fileName.substring(0, fileName.length() - 8);
-                }
-                fileName += "-" + dateFormat.format(new Date()) + ".session";
-            } else {
-                Path sessionPath = getSessionPath(fileName);
-                fileName = sessionPath.toAbsolutePath().toString();
-
-                if (Files.exists(sessionPath)) {
-                    final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
-                    boolean sameSession = false;
-                    try {
-                        sameSession =
-                                Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
-                    } catch (IOException e) {
-                        LOGGER.error("Failed to check if same session path:", e);
-                        throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                    }
-
-                    if (!overwrite || sameSession) {
-                        throw new ApiException(ApiException.Type.ALREADY_EXISTS, fileName);
-                    }
-                }
-            }
-
-            this.savingSession = true;
-            try {
-                Control.getSingleton().snapshotSession(fileName, this);
-            } catch (Exception e) {
-                LOGGER.error("Failed to snapshot the session:", e);
-                this.savingSession = false;
-                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-            }
-            // Wait for notification that its worked ok
-            try {
-                while (this.savingSession) {
-                    Thread.sleep(200);
-                }
-            } catch (InterruptedException e) {
-                // Probably not an error
-                LOGGER.debug(e.getMessage(), e);
-            }
-            LOGGER.debug("Can now return after saving session");
-
-        } else if (ACTION_LOAD_SESSION.equalsIgnoreCase(
-                name)) { // Ignore case for backwards compatibility
-            Path sessionPath = getSessionPath(params.getString(PARAM_SESSION));
-            String filename = sessionPath.toAbsolutePath().toString();
-
-            if (!Files.exists(sessionPath)) {
-                throw new ApiException(ApiException.Type.DOES_NOT_EXIST, filename);
-            }
-            try {
-                Control.getSingleton().runCommandLineOpenSession(filename);
-            } catch (Exception e) {
-                LOGGER.error("Failed to load the session:", e);
-                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-            }
-
-        } else if (ACTION_NEW_SESSION.equalsIgnoreCase(
-                name)) { // Ignore case for backwards compatibility
-            String sessionName = null;
-            try {
-                sessionName = params.getString(PARAM_SESSION);
-            } catch (Exception e1) {
-                // Ignore
-            }
-            if (sessionName == null || sessionName.length() == 0) {
-                // Create a new 'unnamed' session
-                Control.getSingleton().discardSession();
-                try {
-                    Control.getSingleton().newSession();
-                } catch (Exception e) {
-                    LOGGER.error("Failed to create a new session:", e);
-                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                }
-            } else {
-                Path sessionPath = getSessionPath(sessionName);
-                String filename = sessionPath.toAbsolutePath().toString();
-
-                final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
-
-                if (Files.exists(sessionPath) && !overwrite) {
-                    throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
-                }
-                try {
-                    Control.getSingleton().runCommandLineNewSession(filename);
-                } catch (Exception e) {
-                    LOGGER.error("Failed to create a new session:", e);
-                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                }
-            }
         } else if (ACTION_CLEAR_EXCLUDED_FROM_PROXY.equals(name)) {
             try {
                 session.setExcludeFromProxyRegexs(new ArrayList<>());
@@ -928,6 +792,148 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         } else {
             throw new ApiException(ApiException.Type.BAD_ACTION);
         }
+
+        final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
+
+        if (Files.exists(sessionPath)) {
+            boolean sameSession = false;
+            if (overwrite && !session.isNewState()) {
+                try {
+                    sameSession = Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
+                } catch (IOException e) {
+                    LOGGER.error("Failed to check if same session path:", e);
+                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+                }
+            }
+
+            if (!overwrite || sameSession) {
+                throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
+            }
+        }
+
+        this.savingSession = true;
+        try {
+            Control.getSingleton().saveSession(filename, this);
+        } catch (Exception e) {
+            LOGGER.error("Failed to save the session:", e);
+            this.savingSession = false;
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+            // Wait for notification that its worked ok
+        try {
+            while (this.savingSession) {
+                Thread.sleep(200);
+            }
+        } catch (InterruptedException e) {
+            // Probably not an error
+            LOGGER.debug(e.getMessage(), e);
+        }
+
+        LOGGER.debug("Can now return after saving session");
+
+        if (session.isNewState()) {
+            throw new ApiException(ApiException.Type.DOES_NOT_EXIST);
+        }
+
+        List<String> actions = Control.getSingleton().getExtensionLoader().getActiveActions();
+        if (!actions.isEmpty()) {
+            throw new ApiException(
+                    ApiException.Type.BAD_STATE,
+                    "Active actions prevent the session snapshot: " + actions);
+        }
+
+        String fileName = ApiUtils.getOptionalStringParam(params, PARAM_SESSION);
+
+        if (fileName == null || fileName.isEmpty()) {
+            fileName = session.getFileName();
+
+            if (fileName.endsWith(".session")) {
+                fileName = fileName.substring(0, fileName.length() - 8);
+            }
+            fileName += "-" + dateFormat.format(new Date()) + ".session";
+        } else {
+            Path sessionPath = getSessionPath(fileName);
+            fileName = sessionPath.toAbsolutePath().toString();
+
+            if (Files.exists(sessionPath)) {
+                final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
+                boolean sameSession = false;
+                try {
+                    sameSession =
+                            Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
+                } catch (IOException e) {
+                    LOGGER.error("Failed to check if same session path:", e);
+                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+                }
+
+                if (!overwrite || sameSession) {
+                    throw new ApiException(ApiException.Type.ALREADY_EXISTS, fileName);
+                }
+            }
+        }
+
+        this.savingSession = true;
+        try {
+            Control.getSingleton().snapshotSession(fileName, this);
+        } catch (Exception e) {
+            LOGGER.error("Failed to snapshot the session:", e);
+            this.savingSession = false;
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+        // Wait for notification that its worked ok
+        try {
+            while (this.savingSession) {
+                Thread.sleep(200);
+            }
+        } catch (InterruptedException e) {
+            // Probably not an error
+            LOGGER.debug(e.getMessage(), e);
+        }
+
+        LOGGER.debug("Can now return after saving session");
+
+        if (!Files.exists(sessionPath)) {
+            throw new ApiException(ApiException.Type.DOES_NOT_EXIST, filename);
+        }
+        try {
+            Control.getSingleton().runCommandLineOpenSession(filename);
+        } catch (Exception e) {
+            LOGGER.error("Failed to load the session:", e);
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+
+        String sessionName = null;
+        try {
+            sessionName = params.getString(PARAM_SESSION);
+        } catch (Exception e1) {
+            // Ignore
+        }
+        if (sessionName == null || sessionName.length() == 0) {
+            // Create a new 'unnamed' session
+            Control.getSingleton().discardSession();
+            try {
+                Control.getSingleton().newSession();
+            } catch (Exception e) {
+                LOGGER.error("Failed to create a new session:", e);
+                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+            }
+        } else {
+            Path sessionPath = getSessionPath(sessionName);
+            String filename = sessionPath.toAbsolutePath().toString();
+
+            final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
+
+            if (Files.exists(sessionPath) && !overwrite) {
+                throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
+            }
+            try {
+                Control.getSingleton().runCommandLineNewSession(filename);
+            } catch (Exception e) {
+                LOGGER.error("Failed to create a new session:", e);
+                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+            }
+        }
+
         return ApiResponseElement.OK;
     }
 
@@ -948,6 +954,52 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_FILENAME);
         }
         return childPath;
+    }
+
+    private ApiResponse handleSaveSession(JSONObject params) throws ApiException {
+        Session session = Model.getSingleton().getSession();
+
+        Path sessionPath = getSessionPath(params.getString(PARAM_SESSION));
+        String filename = sessionPath.toAbsolutePath().toString();
+
+        final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
+
+        if (Files.exists(sessionPath)) {
+            boolean sameSession = false;
+            if (overwrite && !session.isNewState()) {
+                try {
+                    sameSession = Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
+                } catch (IOException e) {
+                    LOGGER.error("Failed to check if same session path:", e);
+                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+                }
+            }
+
+            if (!overwrite || sameSession) {
+                throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
+            }
+        }
+
+        this.savingSession = true;
+        try {
+            Control.getSingleton().saveSession(filename, this);
+        } catch (Exception e) {
+            LOGGER.error("Failed to save the session:", e);
+            this.savingSession = false;
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+
+        try {
+            while (this.savingSession) {
+                Thread.sleep(200);
+            }
+        } catch (InterruptedException e) {
+            LOGGER.debug(e.getMessage(), e);
+        }
+
+        LOGGER.debug("Can now return after saving session");
+        
+        return ApiResponseElement.OK;
     }
 
     private static Path getSessionPath(String path) throws ApiException {
@@ -1797,6 +1849,10 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
     private interface Processor<T> {
 
         void process(T object);
+    }
+
+    private interface ApiActionCommand{
+        ApiResponse execute(JSONObject params) throws ApiException;
     }
 
     private static class CounterProcessor<T> implements Processor<T> {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -501,11 +501,11 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         registerActionCommands();
     }
 
-    private void registerActionCommands(){
+    private void registerActionCommands() {
+        actionCommands.put(ACTION_LOAD_SESSION.toLowerCase(), this::handleLoadSession);
+        actionCommands.put(ACTION_NEW_SESSION.toLowerCase(), this::handleNewSession);
         actionCommands.put(ACTION_SAVE_SESSION.toLowerCase(), this::handleSaveSession);
-        actionCommands.put(ACTION_SNAPSHOT_SESSION, this::handleSnapshotSession);
-        actionCommands.put(ACTION_LOAD_SESSION, this::handleLoadSession);
-        actionCommands.put(ACTION_NEW_SESSION, this::handleNewSession);
+        actionCommands.put(ACTION_SNAPSHOT_SESSION.toLowerCase(), this::handleSnapshotSession);
     }
 
     private <T extends ApiElement> T deprecatedNetworkApi(T element) {
@@ -539,7 +539,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
 
         ApiActionCommand command = actionCommands.get(name.toLowerCase());
-        if(command != null){
+        if (command != null) {
             return command.execute(params);
         }
 
@@ -789,149 +789,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         "Invalid log level: \"" + newLevel + "\"");
             }
             Configurator.setLevel(logName, logLevel);
+
         } else {
             throw new ApiException(ApiException.Type.BAD_ACTION);
-        }
-
-        final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
-
-        if (Files.exists(sessionPath)) {
-            boolean sameSession = false;
-            if (overwrite && !session.isNewState()) {
-                try {
-                    sameSession = Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
-                } catch (IOException e) {
-                    LOGGER.error("Failed to check if same session path:", e);
-                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                }
-            }
-
-            if (!overwrite || sameSession) {
-                throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
-            }
-        }
-
-        this.savingSession = true;
-        try {
-            Control.getSingleton().saveSession(filename, this);
-        } catch (Exception e) {
-            LOGGER.error("Failed to save the session:", e);
-            this.savingSession = false;
-            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-        }
-            // Wait for notification that its worked ok
-        try {
-            while (this.savingSession) {
-                Thread.sleep(200);
-            }
-        } catch (InterruptedException e) {
-            // Probably not an error
-            LOGGER.debug(e.getMessage(), e);
-        }
-
-        LOGGER.debug("Can now return after saving session");
-
-        if (session.isNewState()) {
-            throw new ApiException(ApiException.Type.DOES_NOT_EXIST);
-        }
-
-        List<String> actions = Control.getSingleton().getExtensionLoader().getActiveActions();
-        if (!actions.isEmpty()) {
-            throw new ApiException(
-                    ApiException.Type.BAD_STATE,
-                    "Active actions prevent the session snapshot: " + actions);
-        }
-
-        String fileName = ApiUtils.getOptionalStringParam(params, PARAM_SESSION);
-
-        if (fileName == null || fileName.isEmpty()) {
-            fileName = session.getFileName();
-
-            if (fileName.endsWith(".session")) {
-                fileName = fileName.substring(0, fileName.length() - 8);
-            }
-            fileName += "-" + dateFormat.format(new Date()) + ".session";
-        } else {
-            Path sessionPath = getSessionPath(fileName);
-            fileName = sessionPath.toAbsolutePath().toString();
-
-            if (Files.exists(sessionPath)) {
-                final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
-                boolean sameSession = false;
-                try {
-                    sameSession =
-                            Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
-                } catch (IOException e) {
-                    LOGGER.error("Failed to check if same session path:", e);
-                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                }
-
-                if (!overwrite || sameSession) {
-                    throw new ApiException(ApiException.Type.ALREADY_EXISTS, fileName);
-                }
-            }
-        }
-
-        this.savingSession = true;
-        try {
-            Control.getSingleton().snapshotSession(fileName, this);
-        } catch (Exception e) {
-            LOGGER.error("Failed to snapshot the session:", e);
-            this.savingSession = false;
-            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-        }
-        // Wait for notification that its worked ok
-        try {
-            while (this.savingSession) {
-                Thread.sleep(200);
-            }
-        } catch (InterruptedException e) {
-            // Probably not an error
-            LOGGER.debug(e.getMessage(), e);
-        }
-
-        LOGGER.debug("Can now return after saving session");
-
-        if (!Files.exists(sessionPath)) {
-            throw new ApiException(ApiException.Type.DOES_NOT_EXIST, filename);
-        }
-        try {
-            Control.getSingleton().runCommandLineOpenSession(filename);
-        } catch (Exception e) {
-            LOGGER.error("Failed to load the session:", e);
-            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-        }
-
-        String sessionName = null;
-        try {
-            sessionName = params.getString(PARAM_SESSION);
-        } catch (Exception e1) {
-            // Ignore
-        }
-        if (sessionName == null || sessionName.length() == 0) {
-            // Create a new 'unnamed' session
-            Control.getSingleton().discardSession();
-            try {
-                Control.getSingleton().newSession();
-            } catch (Exception e) {
-                LOGGER.error("Failed to create a new session:", e);
-                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-            }
-        } else {
-            Path sessionPath = getSessionPath(sessionName);
-            String filename = sessionPath.toAbsolutePath().toString();
-
-            final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
-
-            if (Files.exists(sessionPath) && !overwrite) {
-                throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
-            }
-            try {
-                Control.getSingleton().runCommandLineNewSession(filename);
-            } catch (Exception e) {
-                LOGGER.error("Failed to create a new session:", e);
-                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-            }
         }
 
         return ApiResponseElement.OK;
@@ -956,6 +816,61 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         return childPath;
     }
 
+    private ApiResponse handleLoadSession(JSONObject params) throws ApiException {
+        Path sessionPath = getSessionPath(params.getString(PARAM_SESSION));
+        String filename = sessionPath.toAbsolutePath().toString();
+
+        if (!Files.exists(sessionPath)) {
+            throw new ApiException(ApiException.Type.DOES_NOT_EXIST, filename);
+        }
+
+        try {
+            Control.getSingleton().runCommandLineOpenSession(filename);
+        } catch (Exception e) {
+            LOGGER.error("Failed to load the session:", e);
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+
+        return ApiResponseElement.OK;
+    }
+
+    private ApiResponse handleNewSession(JSONObject params) throws ApiException {
+        String sessionName = null;
+        try {
+            sessionName = params.getString(PARAM_SESSION);
+        } catch (Exception e) {
+            // Ignore.
+        }
+
+        if (sessionName == null || sessionName.length() == 0) {
+            Control.getSingleton().discardSession();
+            try {
+                Control.getSingleton().newSession();
+            } catch (Exception e) {
+                LOGGER.error("Failed to create a new session:", e);
+                throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+            }
+            return ApiResponseElement.OK;
+        }
+
+        Path sessionPath = getSessionPath(sessionName);
+        String filename = sessionPath.toAbsolutePath().toString();
+        final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
+
+        if (Files.exists(sessionPath) && !overwrite) {
+            throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
+        }
+
+        try {
+            Control.getSingleton().runCommandLineNewSession(filename);
+        } catch (Exception e) {
+            LOGGER.error("Failed to create a new session:", e);
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+
+        return ApiResponseElement.OK;
+    }
+
     private ApiResponse handleSaveSession(JSONObject params) throws ApiException {
         Session session = Model.getSingleton().getSession();
 
@@ -967,12 +882,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         if (Files.exists(sessionPath)) {
             boolean sameSession = false;
             if (overwrite && !session.isNewState()) {
-                try {
-                    sameSession = Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
-                } catch (IOException e) {
-                    LOGGER.error("Failed to check if same session path:", e);
-                    throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
-                }
+                sameSession = isSameSessionFile(session, sessionPath);
             }
 
             if (!overwrite || sameSession) {
@@ -989,6 +899,74 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
         }
 
+        waitForSessionSave();
+
+        LOGGER.debug("Can now return after saving session");
+
+        return ApiResponseElement.OK;
+    }
+
+    private ApiResponse handleSnapshotSession(JSONObject params) throws ApiException {
+        Session session = Model.getSingleton().getSession();
+
+        if (session.isNewState()) {
+            throw new ApiException(ApiException.Type.DOES_NOT_EXIST);
+        }
+
+        List<String> actions = Control.getSingleton().getExtensionLoader().getActiveActions();
+        if (!actions.isEmpty()) {
+            throw new ApiException(
+                    ApiException.Type.BAD_STATE,
+                    "Active actions prevent the session snapshot: " + actions);
+        }
+
+        String filename = ApiUtils.getOptionalStringParam(params, PARAM_SESSION);
+        if (filename == null || filename.isEmpty()) {
+            filename = session.getFileName();
+            if (filename.endsWith(".session")) {
+                filename = filename.substring(0, filename.length() - 8);
+            }
+            filename += "-" + dateFormat.format(new Date()) + ".session";
+        } else {
+            Path sessionPath = getSessionPath(filename);
+            filename = sessionPath.toAbsolutePath().toString();
+
+            if (Files.exists(sessionPath)) {
+                final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
+                boolean sameSession = isSameSessionFile(session, sessionPath);
+
+                if (!overwrite || sameSession) {
+                    throw new ApiException(ApiException.Type.ALREADY_EXISTS, filename);
+                }
+            }
+        }
+
+        this.savingSession = true;
+        try {
+            Control.getSingleton().snapshotSession(filename, this);
+        } catch (Exception e) {
+            LOGGER.error("Failed to snapshot the session:", e);
+            this.savingSession = false;
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+
+        waitForSessionSave();
+
+        LOGGER.debug("Can now return after saving session");
+
+        return ApiResponseElement.OK;
+    }
+
+    private static boolean isSameSessionFile(Session session, Path sessionPath) throws ApiException {
+        try {
+            return Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
+        } catch (IOException e) {
+            LOGGER.error("Failed to check if same session path:", e);
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+        }
+    }
+
+    private void waitForSessionSave() {
         try {
             while (this.savingSession) {
                 Thread.sleep(200);
@@ -996,10 +974,6 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         } catch (InterruptedException e) {
             LOGGER.debug(e.getMessage(), e);
         }
-
-        LOGGER.debug("Can now return after saving session");
-        
-        return ApiResponseElement.OK;
     }
 
     private static Path getSessionPath(String path) throws ApiException {
@@ -1197,57 +1171,63 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         if (VIEW_HOSTS.equals(name)) {
             result = new ApiResponseList(name);
             SiteNode root = session.getSiteTree().getRoot();
+
             @SuppressWarnings("unchecked")
             Enumeration<TreeNode> en = root.children();
+
             while (en.hasMoreElements()) {
                 String site = ((SiteNode) en.nextElement()).getNodeName();
+
                 if (site.indexOf("//") >= 0) {
                     site = site.substring(site.indexOf("//") + 2);
                 }
+
                 if (site.indexOf(":") >= 0) {
                     site = site.substring(0, site.indexOf(":"));
                 }
+
                 ((ApiResponseList) result).addItem(new ApiResponseElement("host", site));
             }
         } else if (VIEW_SITES.equals(name)) {
             ApiResponseList sitesList = new ApiResponseList(name);
             StructuralNode root = SessionStructure.getRootNode(model);
+
             if (root != null) {
                 for (Iterator<StructuralNode> it = root.getChildIterator(); it.hasNext(); ) {
                     sitesList.addItem(new ApiResponseElement("site", it.next().getName()));
                 }
             }
+
             result = sitesList;
         } else if (VIEW_URLS.equals(name)) {
             result = new ApiResponseList(name);
             SiteNode root = session.getSiteTree().getRoot();
+
             addUrlsToList(
-                    getParam(params, PARAM_BASE_URL, ""),
+                    this.getParam(params, PARAM_BASE_URL, ""),
                     root,
                     new HashSet<>(),
                     (ApiResponseList) result);
         } else if (VIEW_CHILD_NODES.equals(name)) {
             StructuralNode node;
             String url = this.getParam(params, PARAM_URL, "");
-
             if (url.trim().length() == 0) {
                 node = SessionStructure.getRootNode(model);
             } else {
                 try {
-                    node =
-                            SessionStructure.find(
-                                    Model.getSingleton(), new URI(url, false), null, null);
+                    node = SessionStructure.find(model, new URI(url, false), null, null);
                 } catch (URIException e) {
                     throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL, e);
                 } catch (DatabaseException e) {
                     throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
                 }
             }
+
             if (node == null) {
                 throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_URL);
             }
-            result = new ApiResponseList(name);
 
+            result = new ApiResponseList(name);
             Iterator<StructuralNode> iter = node.getChildIterator();
             while (iter.hasNext()) {
                 ((ApiResponseList) result).addItem(structuralNodeToResponse(iter.next()));
@@ -1851,7 +1831,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         void process(T object);
     }
 
-    private interface ApiActionCommand{
+    private interface ApiActionCommand {
         ApiResponse execute(JSONObject params) throws ApiException;
     }
 


### PR DESCRIPTION
Closes #34

Problem 
CoreAPI. handleAction uses a long if/else if statement chain to dispatch unrelated API actions. This mixes routing, validation, session behavior, file system behavior, shutdown logic and http request handling in one method

Approach 
started decoupling API action dispatch using command pattern

Changes
Introduce APIActionCommand interface, add command lookup map for selected actions, register session related API commands and move targeted session action handling out of central if/else if

Design Pattern
Command Pattern, behavioral category

Scope 
Focuses only on session related API actions. It does not migrate the full API action 

Verification
Build Attempted

Before 
handleApiAction() routed all actions directly 
Session actions lived inside the central conditional chain 
Adding/changing actions required editing one fragile method 

After
handleApiAction() checks command map first 
Session actions are dispatched through command handlers 
Migrated action behavior lives dedicated handler method 

No behavior change 