### PR TITLE
630:P3 God Object in AddOn dependency checking

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -62,12 +62,11 @@ import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.extension.Extension;
 import org.zaproxy.zap.Version;
 import org.zaproxy.zap.control.AddOn.AddOnRunRequirements;
+//import org.zaproxy.zap.control.AddOn.AddOnRunRequirements;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.AddOnDep;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.Dependencies;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.ExtensionWithDeps;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
-
-import org.parosproxy.paros.control.Control;
 
 public class AddOn {
 
@@ -99,13 +98,13 @@ public class AddOn {
         release
     }
 
-    private static final List<RequirementCheck> REQUIREMENT_CHECKS = List.of(
-        new MissingLibsCheck(),
-        new InstalledVersionCheck(),
-        new CycleCheck(),
-        new JavaVersionCheck(),
-        new DependencyVersionCheck()
-    );
+    private static final List<RequirementCheck> REQUIREMENT_CHECKS =
+        List.of(
+            new MissingLibsCheck(),
+            new InstalledVersionCheck(),
+            new CycleCheck(),
+            new JavaVersionCheck(),
+            new DependencyVersionCheck());
 
     private static ZapRelease v2_4 = new ZapRelease("2.4.0");
 
@@ -1218,14 +1217,16 @@ public class AddOn {
             AddOn addOn,
             boolean checkLibs) {
 
-            RequirementEvaluation evaluation = new RequirementEvaluation(availableAddOns, requirements, parent, addOn, checkLibs);
+        RequirementEvaluation evaluation =
+                new RequirementEvaluation(availableAddOns, requirements, parent, addOn, checkLibs);
 
-            for (RequirementCheck check : REQUIREMENT_CHECKS) {
-                if (!check.evaluate(evaluation)) {
-                    return;
-                }
+        for (RequirementCheck check : REQUIREMENT_CHECKS) {
+            if (!check.evaluate(evaluation)) {
+                return;
             }
         }
+    }
+
     private static void checkExtensionsWithDeps(
             Collection<AddOn> availableAddOns,
             AddOnRunRequirements requirements,
@@ -2421,10 +2422,11 @@ public class AddOn {
     private static class InstalledVersionCheck implements RequirementCheck {
         @Override
         public boolean evaluate(RequirementEvaluation evaluation) {
-            AddOn installedAddOn = getAddOn(Control.getSingleton().getExtensionLoader().getInstalledAddOns(), evaluation.addOn.getId());
+            AddOn installedVersion = getAddOn(evaluation.availableAddOns, evaluation.addOn.getId());
 
-            if (installedAddOn != null && installedAddOn.getVersion().compareTo(evaluation.addOn.getVersion()) >= 0) {
-                evaluation.requirements.setIssue(BaseRunRequirements.DependencyIssue.OLDER_VERSION, installedAddOn);
+            if (installedVersion != null && !evaluation.addOn.equals(installedVersion)) {
+                evaluation.requirements.setIssue(
+                        BaseRunRequirements.DependencyIssue.OLDER_VERSION, installedVersion);
                 return false;
             }
 
@@ -2436,7 +2438,9 @@ public class AddOn {
         @Override
         public boolean evaluate(RequirementEvaluation evaluation) {
             if (!evaluation.requirements.addDependency(evaluation.parent, evaluation.addOn)) {
-                evaluation.requirements.setIssue(BaseRunRequirements.DependencyIssue.CYCLIC);
+                evaluation.requirements.setIssue(
+                        BaseRunRequirements.DependencyIssue.CYCLIC,
+                        evaluation.requirements.getDependencies().toArray());
                 return false;
             }
 
@@ -2450,8 +2454,8 @@ public class AddOn {
             String minimumJavaVersion = evaluation.addOn.getMinimumJavaVersion();
 
             if (!minimumJavaVersion.isEmpty() && !evaluation.addOn.canRunInCurrentJavaVersion()) {
-                evaluation.requirements.setMinimumJavaVersionIssue(evaluation.addOn, minimumJavaVersion);
-                return false;
+                evaluation.requirements.setMinimumJavaVersionIssue(
+                        evaluation.addOn, minimumJavaVersion);
             }
 
             return true;
@@ -2480,14 +2484,12 @@ public class AddOn {
                     return false;
                 }
 
-                if (!dependency.getVersion().isEmpty()) {
-                    if (!versionMatches(addOnDep, dependency)) {
-                        evaluation.requirements.setIssue(
-                                BaseRunRequirements.DependencyIssue.VERSION,
-                                addOnDep,
-                                dependency.getVersion());
-                        return false;
-                    }
+                if (!dependency.getVersion().isEmpty() && !versionMatches(addOnDep, dependency)) {
+                    evaluation.requirements.setIssue(
+                            BaseRunRequirements.DependencyIssue.VERSION,
+                            addOnDep,
+                            dependency.getVersion());
+                    return false;
                 }
 
                 calculateRunRequirementsImpl(
@@ -2496,6 +2498,10 @@ public class AddOn {
                         evaluation.addOn,
                         addOnDep,
                         evaluation.checkLibs);
+
+                if (evaluation.requirements.hasDependencyIssue()) {
+                    return false;
+                }
             }
 
             return true;

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -61,10 +61,13 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.extension.Extension;
 import org.zaproxy.zap.Version;
+import org.zaproxy.zap.control.AddOn.AddOnRunRequirements;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.AddOnDep;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.Dependencies;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.ExtensionWithDeps;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+import org.parosproxy.paros.control.Control;
 
 public class AddOn {
 
@@ -95,6 +98,14 @@ public class AddOn {
         weekly,
         release
     }
+
+    private static final List<RequirementCheck> REQUIREMENT_CHECKS = List.of(
+        new MissingLibsCheck(),
+        new InstalledVersionCheck(),
+        new CycleCheck(),
+        new JavaVersionCheck(),
+        new DependencyVersionCheck()
+    );
 
     private static ZapRelease v2_4 = new ZapRelease("2.4.0");
 
@@ -1206,65 +1217,15 @@ public class AddOn {
             AddOn parent,
             AddOn addOn,
             boolean checkLibs) {
-        if (checkLibs && addOn.hasMissingLibs()) {
-            requirements.setMissingLibsIssue(addOn);
-            return;
-        }
 
-        AddOn installedVersion = getAddOn(availableAddOns, addOn.getId());
-        if (installedVersion != null && !addOn.equals(installedVersion)) {
-            requirements.setIssue(
-                    BaseRunRequirements.DependencyIssue.OLDER_VERSION, installedVersion);
-            LOGGER.debug(
-                    "Add-on {} not runnable, old version still installed: {}",
-                    addOn,
-                    installedVersion);
-            return;
-        }
+            RequirementEvaluation evaluation = new RequirementEvaluation(availableAddOns, requirements, parent, addOn, checkLibs);
 
-        if (!requirements.addDependency(parent, addOn)) {
-            LOGGER.warn("Cyclic dependency detected with: {}", requirements.getDependencies());
-            requirements.setIssue(
-                    BaseRunRequirements.DependencyIssue.CYCLIC, requirements.getDependencies());
-            return;
-        }
-
-        if (addOn.dependencies == null) {
-            return;
-        }
-
-        if (!addOn.canRunInCurrentJavaVersion()) {
-            requirements.setMinimumJavaVersionIssue(addOn, addOn.dependencies.getJavaVersion());
-        }
-
-        for (AddOnDep dependency : addOn.dependencies.getAddOns()) {
-            String addOnId = dependency.getId();
-            if (addOnId != null) {
-                AddOn addOnDep = getAddOn(availableAddOns, addOnId);
-                if (addOnDep == null) {
-                    requirements.setIssue(BaseRunRequirements.DependencyIssue.MISSING, addOnId);
-                    return;
-                }
-
-                if (!dependency.getVersion().isEmpty()) {
-                    if (!versionMatches(addOnDep, dependency)) {
-                        requirements.setIssue(
-                                BaseRunRequirements.DependencyIssue.VERSION,
-                                addOnDep,
-                                dependency.getVersion());
-                        return;
-                    }
-                }
-
-                calculateRunRequirementsImpl(
-                        availableAddOns, requirements, addOn, addOnDep, checkLibs);
-                if (requirements.hasDependencyIssue()) {
+            for (RequirementCheck check : REQUIREMENT_CHECKS) {
+                if (!check.evaluate(evaluation)) {
                     return;
                 }
             }
         }
-    }
-
     private static void checkExtensionsWithDeps(
             Collection<AddOn> availableAddOns,
             AddOnRunRequirements requirements,
@@ -2417,5 +2378,127 @@ public class AddOn {
             }
         }
         return null;
+    }
+
+    private interface RequirementCheck {
+        boolean evaluate(RequirementEvaluation evaluation);
+    }
+
+    private static class RequirementEvaluation {
+        private final Collection<AddOn> availableAddOns;
+        private final BaseRunRequirements requirements;
+        private final AddOn parent;
+        private final AddOn addOn;
+        private final boolean checkLibs;
+
+        RequirementEvaluation(
+                Collection<AddOn> availableAddOns,
+                BaseRunRequirements requirements,
+                AddOn parent,
+                AddOn addOn,
+                boolean checkLibs) {
+
+            this.availableAddOns = availableAddOns;
+            this.requirements = requirements;
+            this.parent = parent;
+            this.addOn = addOn;
+            this.checkLibs = checkLibs;
+        }
+    }
+
+    private static class MissingLibsCheck implements RequirementCheck {
+        @Override
+        public boolean evaluate(RequirementEvaluation evaluation) {
+            if (evaluation.checkLibs && evaluation.addOn.hasMissingLibs()) {
+                evaluation.requirements.setMissingLibsIssue(evaluation.addOn);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private static class InstalledVersionCheck implements RequirementCheck {
+        @Override
+        public boolean evaluate(RequirementEvaluation evaluation) {
+            AddOn installedAddOn = getAddOn(Control.getSingleton().getExtensionLoader().getInstalledAddOns(), evaluation.addOn.getId());
+
+            if (installedAddOn != null && installedAddOn.getVersion().compareTo(evaluation.addOn.getVersion()) >= 0) {
+                evaluation.requirements.setIssue(BaseRunRequirements.DependencyIssue.OLDER_VERSION, installedAddOn);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private static class CycleCheck implements RequirementCheck {
+        @Override
+        public boolean evaluate(RequirementEvaluation evaluation) {
+            if (!evaluation.requirements.addDependency(evaluation.parent, evaluation.addOn)) {
+                evaluation.requirements.setIssue(BaseRunRequirements.DependencyIssue.CYCLIC);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private static class JavaVersionCheck implements RequirementCheck {
+        @Override
+        public boolean evaluate(RequirementEvaluation evaluation) {
+            String minimumJavaVersion = evaluation.addOn.getMinimumJavaVersion();
+
+            if (!minimumJavaVersion.isEmpty() && !evaluation.addOn.canRunInCurrentJavaVersion()) {
+                evaluation.requirements.setMinimumJavaVersionIssue(evaluation.addOn, minimumJavaVersion);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private static class DependencyVersionCheck implements RequirementCheck {
+        @Override
+        public boolean evaluate(RequirementEvaluation evaluation) {
+            if (evaluation.addOn.dependencies == null) {
+                return true;
+            }
+
+            for (AddOnDep dependency : evaluation.addOn.dependencies.getAddOns()) {
+                String addOnId = dependency.getId();
+
+                if (addOnId == null) {
+                    continue;
+                }
+
+                AddOn addOnDep = getAddOn(evaluation.availableAddOns, addOnId);
+
+                if (addOnDep == null) {
+                    evaluation.requirements.setIssue(
+                            BaseRunRequirements.DependencyIssue.MISSING, addOnId);
+                    return false;
+                }
+
+                if (!dependency.getVersion().isEmpty()) {
+                    if (!versionMatches(addOnDep, dependency)) {
+                        evaluation.requirements.setIssue(
+                                BaseRunRequirements.DependencyIssue.VERSION,
+                                addOnDep,
+                                dependency.getVersion());
+                        return false;
+                    }
+                }
+
+                calculateRunRequirementsImpl(
+                        evaluation.availableAddOns,
+                        evaluation.requirements,
+                        evaluation.addOn,
+                        addOnDep,
+                        evaluation.checkLibs);
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Closes #36

Problem
AddOn acts as a God Object by combining metadata, install state, classloader handling, dependency data, and requirement-evaluation logic in one class. The requirement workflow is implemented as a single recursive method that performs multiple checks (missing libs, installed version, cycles, Java version, dependency validation) in one place.

Approach
Started decoupling requirement evaluation using the Chain of Responsibility pattern.

Changes
Introduced RequirementCheck interface, added a chain (REQUIREMENT_CHECKS) to represent validation steps, created RequirementEvaluation context object, and extracted requirement checks into separate handlers:
- MissingLibsCheck
- InstalledVersionCheck
- CycleCheck
- JavaVersionCheck
- DependencyVersionCheck

Moved validation orchestration out of the central method into a handler chain while keeping AddOn as the domain object.

Design Pattern
Chain of Responsibility, Behavioral category

Scope
Focuses only on requirement-evaluation logic. It does not redesign the full add-on subsystem or metadata handling.

Verification
Build attempted

Before
Requirement evaluation was implemented in a single recursive method, multiple validation rules were tightly coupled in one block, and changing one rule risked breaking unrelated logic

After
Requirement evaluation is executed through a chain of handlers, each validation rule is isolated in its own class, and AddOn delegates requirement evaluation instead of owning all logic

No behavior change intended.