### PR TITLE
630:P3 #43 Extract options reset workflow into Command

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/view/OptionsDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/OptionsDialog.java
@@ -79,47 +79,66 @@ public class OptionsDialog extends AbstractParamDialog {
                     new ActionListener() {
                         @Override
                         public void actionPerformed(ActionEvent e) {
-                            if (View.getSingleton()
-                                            .showConfirmDialog(
-                                                    OptionsDialog.this,
-                                                    Constant.messages.getString(
-                                                            "options.dialog.reset.warn"))
-                                    == JOptionPane.OK_OPTION) {
-                                try {
-                                    OptionsParam params = Model.getSingleton().getOptionsParam();
-                                    // Force the install files to be copied
-                                    Constant.getInstance()
-                                            .copyDefaultConfigs(
-                                                    new File(Constant.getInstance().FILE_CONFIG),
-                                                    true);
-                                    // Load them
-                                    params.load(Constant.getInstance().FILE_CONFIG);
-                                    // Force a reload in all of the option params
-                                    params.reloadConfigParamSets();
-                                    params.resetAll();
-
-                                    resetAllPanels();
-                                    // Reinit the dialog
-                                    OptionsDialog.this.initParam(params);
-
-                                } catch (Exception e1) {
-                                    LOGGER.error("Failed to reset to defaults:", e1);
-                                    View.getSingleton()
-                                            .showWarningDialog(
-                                                    Constant.messages.getString(
-                                                            "options.dialog.reset.error",
-                                                            e1.getMessage()));
-                                }
+                            if (confirmReset()) {
+                                new ResetOptionsCommand().execute();
                             }
                         }
                     });
             extraButtons = new JButton[] {resetButton};
         }
+
         return extraButtons;
     }
 
-    private void resetAllPanels() {
-        for (AbstractParamPanel panel : OptionsDialog.this.getPanels()) {
+    private boolean confirmReset() {
+        return View.getSingleton()
+                        .showConfirmDialog(
+                                OptionsDialog.this,
+                                Constant.messages.getString("options.dialog.reset.warn"))
+                == JOptionPane.OK_OPTION;
+    }
+
+    private final class ResetOptionsCommand {
+
+        private void execute() {
+            try {
+                OptionsParam params = resetOptionsToDefaults();
+                params.resetAll();
+                resetAllPanels();
+
+                // Reinit the dialog
+                OptionsDialog.this.initParam(params);
+            } catch (Exception e) {
+                LOGGER.error("Failed to reset to defaults:", e);
+                View.getSingleton()
+                        .showWarningDialog(
+                                Constant.messages.getString(
+                                        "options.dialog.reset.error", e.getMessage()));
+            }
+        }
+
+        private OptionsParam resetOptionsToDefaults() throws Exception {
+            OptionsParam params = Model.getSingleton().getOptionsParam();
+
+            // Force the install files to be copied
+            Constant.getInstance()
+                    .copyDefaultConfigs(new File(Constant.getInstance().FILE_CONFIG), true);
+
+            // Load them
+            params.load(Constant.getInstance().FILE_CONFIG);
+
+            // Force a reload in all of the option params
+            params.reloadConfigParamSets();
+            return params;
+        }
+
+        private void resetAllPanels() {
+            for (AbstractParamPanel panel : OptionsDialog.this.getPanels()) {
+                resetPanel(panel);
+            }
+        }
+
+        private void resetPanel(AbstractParamPanel panel) {
             try {
                 panel.reset();
             } catch (Exception e) {


### PR DESCRIPTION
```markdown
Closes #43 https://github.com/csci630/zaproxy/issues/43

## Problem
The reset-to-defaults button action in `OptionsDialog` mixed UI event handling with a multi-step reset workflow: confirmation, default config copy, config loading, parameter reload/reset, panel reset, dialog reinitialization, and error handling.

## Approach
Extracted the reset workflow into a private `ResetOptionsCommand` inner class with a clear `execute()` entry point.

The button listener now confirms intent and invokes the command. The command owns the reset sequence and panel-specific warning behavior.

## Pattern
Command, behavioral pattern.

## Verification
- Opened Options dialog and selected the reset button.
- Confirmed the warning prompt still appears.
- Confirmed OK runs the reset workflow and refreshes the dialog.
- Confirmed Cancel leaves settings unchanged.
- Confirmed panel-specific reset failures still surface warning dialogs through the existing message key.
- Ran: `./gradlew spotlessJavaCheck`, `./gradlew :zap:compileJava`, `./gradlew :zap:test`.
```